### PR TITLE
ci(pipelines): setup basic layout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,0 +1,98 @@
+name: CI/CD
+on:
+  pull-request:
+  push:
+    tags:
+      - "v*"
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DISTRIBUTION_ARTIFACTS: "lazyfeed-distribution-artifacts"
+  PROJECT_PYPI_URL: "https://pypi.org/project/lazyfeed"
+
+jobs:
+
+  tests:
+    name: "Test Python ${{ matrix.python }} in ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.10', '3.11', '3.12']
+        os: ['windows-latest', 'ubuntu-latest']
+    steps:
+
+      - name: "Checkout project"
+        uses: actions/checkout@v4
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v2
+
+      - name: "Install Python ${{ matrix.python }}"
+        run: |
+          uv python install ${{ matrix.python }}
+
+      - name: "Install development dependencies"
+        run: |
+          uv sync --all-extras --dev
+
+      - name: "Testing ${{ matrix.python }} in ${{ matrix.os }}"
+        run: |
+          uv run pytest tests
+
+  build:
+    name: "Build distribution artifacts"
+    runs-on: "ubuntu-latest"
+    needs: tests
+    steps:
+
+      - name: "Checkout project"
+        uses: actions/checkout@v4
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v2
+
+      - name: "Install Python ${{ matrix.python }}"
+        run: |
+          uv python install ${{ matrix.python }}
+
+      - name: "Build project"
+        run: |
+          uv build
+
+      - name: "Upload distribution artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/
+          name: ${{ env.DISTRIBUTION_ARTIFACTS }}
+
+  release:
+    name: "Release project"
+    runs-on: "ubuntu-latest"
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/project/lazyfeed
+    permissions:
+      id-token: write
+    steps:
+
+      - name: "Download distribution artifacts"
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.DISTRIBUTION_ARTIFACTS }}
+          path: dist
+
+      - name: "Release to PyPI"
+        uses: pypa/gh-action-pypi-publish@release/v1.10.2
+        with:
+          packages-dir: dist
+          print-hash: true
+          skip-existing: true
+

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,7 +13,6 @@ concurrency:
 
 env:
   DISTRIBUTION_ARTIFACTS: "lazyfeed-distribution-artifacts"
-  PROJECT_PYPI_URL: "https://pypi.org/project/lazyfeed"
 
 jobs:
 


### PR DESCRIPTION
Fix #3 by adding some basic CI/CD pipelines. Three jobs are declared: tests, build, and release. These are dependent on the previous one. The release job only triggers when tagging a commit.

It also enables [dependabot](https://github.com/dependabot). This GitHub tool opens a pull-request whenever there is a new version of a dependency, which triggers the CI/CD to verify it is compatible with the project.